### PR TITLE
Add final selection page, integrate lobbies with restaurant selections, add voting and scoring

### DIFF
--- a/back-end/src/models/Lobby.js
+++ b/back-end/src/models/Lobby.js
@@ -37,6 +37,9 @@ const LobbySchema = new mongoose.Schema(
     votes: {
       type: [Object],
     },
+    winner: {
+      type: Object,
+    }
   },
   { timestamps: true }
 );

--- a/back-end/src/models/index.ts
+++ b/back-end/src/models/index.ts
@@ -35,3 +35,33 @@ export interface Vote {
   restaurant_id: string;
   vote: VoteResult;
 }
+
+export interface Filters {
+  numberRestaurants: number;
+  distanceLow: number; // remove?
+  ratingLow: number;
+  priceLow: number;
+  reviewCountLow: number;
+  distanceHigh: number;
+  ratingHigh: number;
+  priceHigh: number;
+  reviewCountHigh: number; // remove?
+};
+
+// https://www.yelp.com/developers/documentation/v3/business_search
+export interface YelpBusinessSearchResponse {
+  id: string;
+  categories: { alias: string; title: string }[];
+  coordinates: { latitude: number; longitude: number };
+  distance: number; // meters
+  image_url: string;
+  is_closed: boolean; // permanently closed
+  location: {
+    display_address: string[]; // Array of strings that if organized vertically give an address that is in the standard address format for the business's country.
+  };
+  name: string;
+  phone: string;
+  price?: string;
+  rating: number;
+  review_count: number;
+}

--- a/front-end/src/actions/index.ts
+++ b/front-end/src/actions/index.ts
@@ -15,10 +15,10 @@ export const setRestaurants = (restaurants: Restaurant[]) => {
   };
 };
 
-export const setLobbies = (lobbies: Lobby[]) => {
+export const setLobby = (lobby: Lobby) => {
   return {
-    type: "SET_LOBBIES",
-    payload: lobbies,
+    type: "SET_LOBBY",
+    payload: lobby,
   };
 };
 

--- a/front-end/src/components/layout/LayoutWithAppbar.tsx
+++ b/front-end/src/components/layout/LayoutWithAppbar.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import ResponsiveAppBar from '../widgets/ResponsiveAppBar';
+import UserWidget from '../widgets/UserWidget';
 
 function LayoutWithAppbar(props: React.PropsWithChildren<{}>) {
   return (
     <div id="root">
         <ResponsiveAppBar/>
+        <UserWidget></UserWidget>
         <div id="content">
             {props.children}
         </div>

--- a/front-end/src/components/pages/LobbySelection.tsx
+++ b/front-end/src/components/pages/LobbySelection.tsx
@@ -3,7 +3,7 @@ import LayoutWithAppbar from '../layout/LayoutWithAppbar';
 import { useSelector, useDispatch } from 'react-redux';
 import { ReduxState } from '../../reducers';
 import { useNavigate } from "react-router-dom";
-import { setLobbies } from '../../actions';
+import { setLobby } from '../../actions';
 import { getLobbyAsync } from '../../models/rest';
 import { Lobby } from '../../models';
 import UserWidget from '../widgets/UserWidget';
@@ -15,7 +15,7 @@ import { addLobbyAsync, addLobbyUsersAsync } from '../../models/rest';
 import './LobbySelection.css';
 
 function LobbySelection() {
-    const lobbies = useSelector((state: ReduxState) => state.lobbies);
+    const lobby = useSelector((state: ReduxState) => state.lobby);
     const user = useSelector((state: ReduxState) => state.user);
     const [lobbyCode, setLobbyCode] = useState('');
 
@@ -23,7 +23,7 @@ function LobbySelection() {
     let navigate = useNavigate();
 
     useEffect(() => {
-        dispatch(setLobbies(lobbies));
+        dispatch(setLobby(lobby));
     }, []);
 
 
@@ -47,6 +47,7 @@ function LobbySelection() {
         }
         const lobby: Lobby = { id: roomCode, participants: [user], numberRestaurants: 9, rating: [0, 5], distance: [1, 10], price: [1, 4], reviewCount: [5, 1000], restaurants: [], votes: [] };
         addLobbyAsync(lobby);
+        dispatch(setLobby(lobby));
         navigate('/lobbypage', { state: { id: roomCode } });
     }
 

--- a/front-end/src/components/pages/Selection.tsx
+++ b/front-end/src/components/pages/Selection.tsx
@@ -3,52 +3,67 @@ import LayoutWithAppbar from '../layout/LayoutWithAppbar'
 import sampleData from '../../YelpSampleData.json';
 import {useSelector, useDispatch} from 'react-redux';
 import { ReduxState } from '../../reducers';
-import { Restaurant, YelpBusinessSearchResponse } from '../../models';
-import { setRestaurants } from '../../actions';
+import { Lobby, Restaurant, YelpBusinessSearchResponse } from '../../models';
+import { setLobby, setRestaurants } from '../../actions';
 import RestaurantCard, { Props } from '../widgets/RestaurantCard';
+import { getLobbyAsync } from '../../models/rest';
+import WinnerCard from '../widgets/WinnerCard';
 
 function Selection() {
-  const restaurants = useSelector((state: ReduxState) => state.restaurants);
+  const restaurants = useSelector((state: ReduxState) => state.lobby.restaurants);
+  const lobby = useSelector((state: ReduxState) => state.lobby);
+  const winner = useSelector((state: ReduxState) => state.lobby.winner);
   const [index, setIndex] = React.useState(0);
   const dispatch = useDispatch();
   
   const incrementIndex = () => {
-    setIndex((index + 1) % restaurants.length);
+    setIndex((index + 1));
   }
-  
+
   useEffect(() => {
-    if (restaurants.length === 0) {
-      const restaurants = sampleData.businesses.map((result: YelpBusinessSearchResponse) => {
-        const restaurant: Restaurant = {
-          id: result.id as string,
-          name: result.name,
-          photos: [result.image_url],
-          price_level: result.price,
-          rating: result.rating,
-          user_ratings_total: result.review_count,
-          location: result.coordinates
-        };
-        return restaurant;
-      });
-      dispatch(setRestaurants(restaurants));
+    if (restaurants.length > 0 && index === restaurants.length) {
+      const interval = setInterval(() => {
+        getLobbyAsync(lobby.id).then(res => {
+          const newLobby = res[0];
+          if (newLobby.winner) {
+            dispatch(setLobby(newLobby));
+            clearInterval(interval);
+          }
+        });
+      }, 2000);
     }
-  }, []);
+  }, [index]);
 
   return (
     <LayoutWithAppbar>
-        {restaurants.map(r => {
+        {winner
+        ?
+          <WinnerCard {...{
+            img: winner.photos[0],
+            imgHeight: 400,
+            name: winner.name,
+            rating: winner.rating,
+            numRating: winner.user_ratings_total,
+            restaurantId: winner.id,
+          }}/>
+        : restaurants.length > 0
+        ? index < restaurants.length 
+        ? restaurants.map(r => {
           const rProps: Props = {
             img: r.photos[0],
             imgHeight: 400,
             name: r.name,
             rating: r.rating,
             numRating: r.user_ratings_total,
+            restaurantId: r.id,
             setIndex: incrementIndex
           };
           return (
             <RestaurantCard {...rProps} />
           );
-        })[index]}
+        })[index]
+        : "Calculating..."
+        : "Loading..."}
     </LayoutWithAppbar>
   );
 }

--- a/front-end/src/components/widgets/WinnerCard.tsx
+++ b/front-end/src/components/widgets/WinnerCard.tsx
@@ -3,14 +3,10 @@ import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import CardMedia from '@mui/material/CardMedia';
 import Typography from '@mui/material/Typography';
-import { solid, regular, brands } from '@fortawesome/fontawesome-svg-core/import.macro'
 import './RestaurantCard.css';
 
-import IconButton from './IconButton';
 import { useSelector } from 'react-redux';
 import { ReduxState } from '../../reducers';
-import { Vote } from '../../models';
-import { addVoteAsync } from '../../models/rest';
 
 export interface Props {
   img: string;
@@ -19,7 +15,6 @@ export interface Props {
   rating: number;
   numRating: number;
   restaurantId: string;
-  setIndex: () => void;
 }
 
 // https://mui.com/material-ui/react-card/
@@ -28,16 +23,6 @@ export default function MediaCard(props: any) {
   const user = useSelector((state: ReduxState) => state.user);
   
     const {img, imgHeight, name, rating, numRating, setIndex, restaurantId} = props;
-    const handleClick = (e: React.MouseEvent, liked: boolean) => {
-        e.preventDefault();
-        e.stopPropagation();
-        const vote: Vote = {user_id: user._id, restaurant_id: restaurantId, vote: liked ? 'yes' : 'no'};
-        addVoteAsync(lobby.id, vote).then(() => {
-          setIndex();
-        }).catch(() => {
-          alert("error processing vote.")
-        });
-    }
   return (
     <div className="card-container">
       <Card sx={{ maxWidth: 450 }}>
@@ -56,8 +41,9 @@ export default function MediaCard(props: any) {
         </CardContent>
       </Card>
       <div className="card-button-container">
-        <IconButton size="6x" style={{color: "green"}} icon={solid("circle-check")} onClick={(e)=>handleClick(e, true)}/>
-        <IconButton size="6x" style={{color: "red"}} icon={solid("circle-xmark")} onClick={(e)=>handleClick(e, false)}/>
+      <Typography gutterBottom variant="h5" component="div">
+        Winner
+      </Typography>
       </div>
     </div>
   );

--- a/front-end/src/models/index.ts
+++ b/front-end/src/models/index.ts
@@ -38,6 +38,7 @@ export interface YelpBusinessSearchResponse {
 }
 
 export interface Lobby {
+  winner?: Restaurant;
   id: string;
   participants: User[];
   numberRestaurants: number;
@@ -66,3 +67,21 @@ export interface GoogleNearbyPlaceResponse {
   rating: number;
   user_ratings_total: number;
 }
+
+export interface Filters {
+  numberRestaurants: number;
+  distanceLow: number;
+  ratingLow: number;
+  priceLow: number;
+  reviewCountLow: number;
+  distanceHigh: number;
+  ratingHigh: number;
+  priceHigh: number;
+  reviewCountHigh: number;
+};
+
+export interface RestaurantQuery {
+  latitude: number;
+  longitude: number;
+  filters: Filters;
+};

--- a/front-end/src/models/rest.ts
+++ b/front-end/src/models/rest.ts
@@ -1,4 +1,5 @@
 import { ObjectHTMLAttributes } from "react";
+import { Restaurant, RestaurantQuery, Vote, VoteResult } from ".";
 import userCookies from "./userCookies";
 
 //change stuff to use .env instead of hardcode address
@@ -109,4 +110,67 @@ export const updateFiltersAsync = async (filters: Object) => {
     }
 
     return data;
+}
+
+export const setRestaurantsAsync = async (restaurants: Restaurant[], lobbyId: string | undefined) => {
+    if(!lobbyId) {
+        alert("Error finding lobby ID.");
+        return;
+    }
+    const response = await fetch('http://localhost:5000/lobby/restaurants', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({id: lobbyId, restaurants: restaurants})
+    })
+
+    const data = await response.json();
+    if (!response.ok) {
+        const errorMsg = data?.message;
+        throw new Error(errorMsg);
+    }
+
+    return data;
+}
+
+export const getRestaurantsAsync = async (query: RestaurantQuery) => {
+    const url = (process.env.REACT_APP_BACKEND || 'http://localhost:5000') + '/restaurants/?' +
+    new URLSearchParams({
+      latitude: String(query.latitude),
+      longitude: String(query.longitude),
+      filters: JSON.stringify(query.filters)
+    });
+
+    const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    });
+
+    const data = await response.json();
+    if (!response.ok) {
+        const errorMsg = data?.message;
+        return Promise.reject(errorMsg);
+    }
+
+    return Promise.resolve(data);
+};
+
+export const addVoteAsync = async (lobbyId: string, vote: Vote) => {
+    const response = await fetch('http://localhost:5000/lobby/vote', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({id: lobbyId, vote})
+    })
+    const data = await response.json();
+    if (!response.ok) {
+        const errorMsg = data?.message;
+        return Promise.reject(errorMsg);
+    }
+
+    return Promise.resolve(data);
 }

--- a/front-end/src/reducers/index.ts
+++ b/front-end/src/reducers/index.ts
@@ -23,21 +23,21 @@ const restaurants = (restaurants: Restaurant[] = [], action: Action) => {
   }
 };
 
-const lobbies = (lobbies: Lobby[] = [], action: Action) => {
+const lobby = (lobby: Lobby | null = null, action: Action) => {
   switch (action.type) {
-    case "SET_LOBBIES":
-      return [...action.payload];
+    case "SET_LOBBY":
+      return action.payload;
     default:
-      return lobbies;
+      return lobby;
   }
 }
 
-const rootReducer = combineReducers({ user, restaurants, lobbies });
+const rootReducer = combineReducers({ user, restaurants, lobby });
 
 export interface ReduxState {
   user: User;
   restaurants: Restaurant[];
-  lobbies: Lobby[];
+  lobby: Lobby;
 }
 
 export default rootReducer;


### PR DESCRIPTION
- Updated lobby in redux state to represent 1 lobby instead of an array
- Updated actions and added missing actions where server state was out of sync with redux state
- When clicking 'start search' on /lobbypage/ will now send a query with filters to yelp api and return a real list of restaurants. Filter happens in 2 steps 1) the filters that yelp uses we can just supply as part of the query, 2) take the finished data and filter it again on the returned results. It seems like there are filters we could remove (e.g. max reviews or min distance)
- Vote buttons now add the votes to the lobby. When all participants have voted, then we will calculate the restaurant with the most 'yes' votes. ties will be broken arbitrarily.
- Final selection page now appears after all votes are cast. We check in 2s intervals to see if voting is completed. 

Still todo:

- There is no seperation for hosts and other users so we will need to implement that.
- I think this should work for concurrent users voting at the same time but it is untested.